### PR TITLE
remove warnings

### DIFF
--- a/src/Tabs.jsx
+++ b/src/Tabs.jsx
@@ -28,7 +28,7 @@ class Tabs extends React.Component {
   }
 
   render() {
-    const props = this.props;
+    const { props } = this;
     const { onTabClick, extraContent, animated, prefixCls } = props;
     return (
       <RcTabs
@@ -50,20 +50,15 @@ class Tabs extends React.Component {
   }
 }
 
-Tabs.propTypes = assign({}, RcTabs.propTypes, {
-  activeKey: PropTypes.string,
-  defaultActiveKey: PropTypes.string,
-  onChange: PropTypes.func,
+Tabs.propTypes = {
+  prefixCls: PropTypes.string,
   onTabClick: PropTypes.func,
-  destroyInactiveTabPane: PropTypes.bool,
+  className: PropTypes.string,
   type: PropTypes.oneOf(['large', 'small', 'filter', 'brick']),
   animated: PropTypes.bool,
-  tabBarPosition: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
   extraContent: PropTypes.element,
-});
+};
 
-delete Tabs.propTypes.renderTabBar;
-delete Tabs.propTypes.renderTabContent;
 
 Tabs.defaultProps = assign({}, RcTabs.defaultProps, {
   prefixCls: 'kuma-tab',

--- a/src/Tabs.jsx
+++ b/src/Tabs.jsx
@@ -62,6 +62,9 @@ Tabs.propTypes = assign({}, RcTabs.propTypes, {
   extraContent: PropTypes.element,
 });
 
+delete Tabs.propTypes.renderTabBar;
+delete Tabs.propTypes.renderTabContent;
+
 Tabs.defaultProps = assign({}, RcTabs.defaultProps, {
   prefixCls: 'kuma-tab',
   type: 'large',

--- a/tests/Tabs.spec.jsx
+++ b/tests/Tabs.spec.jsx
@@ -20,14 +20,16 @@ describe('Tabs', () => {
 
   it('has correct propTypes', () => {
     // from api document
-    expect(Tabs.propTypes.activeKey).to.be(PropTypes.string);
-    expect(Tabs.propTypes.defaultActiveKey).to.be(PropTypes.string);
-    expect(Tabs.propTypes.onChange).to.be(PropTypes.func);
+    expect(Tabs.propTypes.prefixCls).to.be(PropTypes.string);
+    expect(Tabs.propTypes.className).to.be(PropTypes.string);
+    // expect(Tabs.propTypes.activeKey).to.be(PropTypes.string);
+    // expect(Tabs.propTypes.defaultActiveKey).to.be(PropTypes.string);
+    // expect(Tabs.propTypes.onChange).to.be(PropTypes.func);
     expect(Tabs.propTypes.onTabClick).to.be(PropTypes.func);
-    expect(Tabs.propTypes.destroyInactiveTabPane).to.be(PropTypes.bool);
+    // expect(Tabs.propTypes.destroyInactiveTabPane).to.be(PropTypes.bool);
     expect(Tabs.propTypes.type).to.be.ok(); // 暂时无法准确检查 oneOf
     expect(Tabs.propTypes.animated).to.be(PropTypes.bool);
-    expect(Tabs.propTypes.tabBarPosition).to.be.ok();
+    // expect(Tabs.propTypes.tabBarPosition).to.be.ok();
     expect(Tabs.propTypes.extraContent).to.be(PropTypes.element);
     expect(Tabs.propTypes.renderTabBar).to.be(undefined);
     expect(Tabs.propTypes.renderTabContent).to.be(undefined);

--- a/tests/Tabs.spec.jsx
+++ b/tests/Tabs.spec.jsx
@@ -25,10 +25,12 @@ describe('Tabs', () => {
     expect(Tabs.propTypes.onChange).to.be(PropTypes.func);
     expect(Tabs.propTypes.onTabClick).to.be(PropTypes.func);
     expect(Tabs.propTypes.destroyInactiveTabPane).to.be(PropTypes.bool);
-    // expect(Tabs.propTypes.type).to.exist; // 暂时无法准确检查 oneOf
+    expect(Tabs.propTypes.type).to.be.ok(); // 暂时无法准确检查 oneOf
     expect(Tabs.propTypes.animated).to.be(PropTypes.bool);
-    // expect(Tabs.propTypes.tabBarPosition).to.exist;
+    expect(Tabs.propTypes.tabBarPosition).to.be.ok();
     expect(Tabs.propTypes.extraContent).to.be(PropTypes.element);
+    expect(Tabs.propTypes.renderTabBar).to.be(undefined);
+    expect(Tabs.propTypes.renderTabContent).to.be(undefined);
   });
 
   it('has a correct sub component', () => {


### PR DESCRIPTION
When upgrading to uxcore 0.6.0 this warning is thrown.
![image](https://cloud.githubusercontent.com/assets/3364271/22816518/81ea9ba0-ef9d-11e6-914d-bead9bc70186.png)

Seems like `rc-tabs` adds prop type checks for `renderTabBar` and `renderTabContent`. 
But we forget to remove them when assigning it to `uxcore-tab.propTypes`

Fixed this in this PR and also update tests.